### PR TITLE
Force Wrangler to use node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,8 @@ jobs:
     - name: Publish to Cloudflare Pages
       uses: cloudflare/wrangler-action@v3
       env:
-        environment: "staging"
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+        environment: "production"
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Publish to Cloudflare Pages
       uses: cloudflare/wrangler-action@v3
       env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
         environment: "staging"
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
This pull request updates the deployment workflows for Cloudflare Pages to ensure compatibility with Node.js 24 and adjusts the deployment environment for production releases.
