### PR TITLE
Add ability to override pnpm cutoff

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,31 +9,52 @@ concurrency:
   group: main
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build-app:
+    permissions:
+      contents: read
+      pull-requests: read
 
     runs-on: ubuntu-latest
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+      - name: Checkout code
+        uses: actions/checkout@v7
 
-    - uses: pnpm/action-setup@v6
-      with:
-        version: 11
-        run_install: true
+      - name: Check for pnpm cutoff bypass
+        id: pnpm-cutoff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '.[0].labels[].name' |
+            grep -Fxq "bypass-pnpm-cutoff"; then
+            echo "bypass=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "bypass=false" >> "${GITHUB_OUTPUT}"
+          fi
 
-    - name: Build App
-      run: |
-        pnpm build
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
 
-    - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v4
-      env:
-        environment: "production"
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: pages deploy build/ --project-name=teddieu-landing-page
+      - name: Bypass pnpm release age cutoff
+        if: steps.pnpm-cutoff.outputs.bypass == 'true'
+        run: pnpm config set minimumReleaseAge 0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build App
+        run: pnpm build
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v4
+        env:
+          environment: "production"
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy build/ --project-name=teddieu-landing-page

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,34 +2,44 @@ name: Build (PR)
 
 on:
   pull_request:
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   build-app:
     permissions:
       contents: read
-      
+
     runs-on: ubuntu-latest
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
+      - name: Checkout code
+        uses: actions/checkout@v7
 
-    - uses: pnpm/action-setup@v6
-      with:
-        version: 11
-        run_install: true
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
 
-    - name: Build App
-      run: |
-        pnpm build
+      - name: Bypass pnpm release age cutoff
+        if: contains(github.event.pull_request.labels.*.name, 'bypass-pnpm-cutoff')
+        run: pnpm config set minimumReleaseAge 0
 
-    - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v4
-      env:
-        environment: "staging"
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: pages deploy build/ --project-name=teddieu-landing-page
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build App
+        run: pnpm build
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v4
+        env:
+          environment: "staging"
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy build/ --project-name=teddieu-landing-page


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve dependency installation and add support for bypassing the `pnpm` release age cutoff via a PR label. It also removes the forced Node.js version environment variable.

**Workflow improvements:**

* Added logic in `.github/workflows/main.yml` to detect the `bypass-pnpm-cutoff` label on a pull request and, if present, set `pnpm`'s `minimumReleaseAge` to `0` to allow installing the latest packages regardless of release age.
* Updated `.github/workflows/pr.yml` to similarly bypass the `pnpm` release age cutoff if the PR has the `bypass-pnpm-cutoff` label.

**Dependency installation changes:**

* Replaced the inline `pnpm` install step with a dedicated "Install dependencies" step in both workflows for clarity and consistency. 

**Other changes:**

* Removed the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable from both workflows, as it is no longer needed. 
* Specified additional PR event types (`labeled`, `unlabeled`, etc.) in `.github/workflows/pr.yml` to ensure the workflow runs when labels are changed.